### PR TITLE
Add Capabilities to check whether the video is a HDR video 

### DIFF
--- a/android/src/main/java/expo/modules/videometadata/ExpoVideoMetadataModule.kt
+++ b/android/src/main/java/expo/modules/videometadata/ExpoVideoMetadataModule.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import java.io.File
 import android.media.MediaExtractor
+import android.media.MediaFeature
 import android.media.MediaFormat
 import java.math.BigDecimal
 import java.math.RoundingMode
@@ -69,6 +70,12 @@ class ExpoVideoMetadataModule : Module() {
           val rotation = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION)?.toIntOrNull()
           val hasAudio = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_HAS_AUDIO) != null
 
+          val colorTransfer = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_COLOR_TRANSFER)?.toIntOrNull()
+          var isHDR: Boolean? = null
+          if (colorTransfer != null) {
+            isHDR = colorTransfer == MediaFormat.COLOR_TRANSFER_ST2084 || colorTransfer == MediaFormat.COLOR_TRANSFER_HLG
+          }
+
           // release
           retriever.release()
 
@@ -115,6 +122,7 @@ class ExpoVideoMetadataModule : Module() {
               "bitrate" to bitrate,
               "fileSize" to fileSize,
               "hasAudio" to hasAudio,
+              "isHDR" to isHDR,
               "audioCodec" to audioCodec,
               "orientation" to getOrientation(rotation),
               "audioSampleRate" to audioSampleRate,

--- a/ios/ExpoVideoMetadataModule.swift
+++ b/ios/ExpoVideoMetadataModule.swift
@@ -30,6 +30,7 @@ public class ExpoVideoMetadataModule: Module {
     var width: Int = 0
     var height: Int = 0
     var frameRate: Float = 0.0
+    var isHDR: Bool? = nil
     var codec: String = ""
     var orientation: String = ""
     var audioSampleRate: Int = 0
@@ -63,6 +64,11 @@ public class ExpoVideoMetadataModule: Module {
       } else {
         orientation = (transform.a == 1.0) ? "LandscapeRight" : "LandscapeLeft"
       }
+
+      // HDR
+      if #available(iOS 14.0, *) {
+        isHDR = videoTrack.hasMediaCharacteristic(.containsHDRVideo)
+      }
     }
 
     // Audio track information
@@ -81,7 +87,7 @@ public class ExpoVideoMetadataModule: Module {
       }
     }
 
-    return [
+    var result: [String: Any] = [
       "duration": duration,
       "hasAudio": hasAudio,
       "fileSize": fileSize,
@@ -95,6 +101,12 @@ public class ExpoVideoMetadataModule: Module {
       "audioChannels": audioChannels,
       "audioCodec": audioCodec
     ]
+
+    if isHDR != nil {
+      result["isHDR"] = isHDR
+    }
+
+    return result
   }
 
   // Helper function to convert FourCC code to String

--- a/ios/ExpoVideoMetadataModule.swift
+++ b/ios/ExpoVideoMetadataModule.swift
@@ -87,9 +87,10 @@ public class ExpoVideoMetadataModule: Module {
       }
     }
 
-    var result: [String: Any] = [
+    return [
       "duration": duration,
       "hasAudio": hasAudio,
+      "isHDR": isHDR,
       "fileSize": fileSize,
       "bitrate": bitrate,
       "fps": frameRate,
@@ -101,12 +102,6 @@ public class ExpoVideoMetadataModule: Module {
       "audioChannels": audioChannels,
       "audioCodec": audioCodec
     ]
-
-    if isHDR != nil {
-      result["isHDR"] = isHDR
-    }
-
-    return result
   }
 
   // Helper function to convert FourCC code to String

--- a/src/ExpoVideoMetadata.types.ts
+++ b/src/ExpoVideoMetadata.types.ts
@@ -8,6 +8,10 @@ export type VideoInfoResult = {
    */
   hasAudio: boolean;
   /**
+   * Available only on iOS >= 14. Tells if the video is a HDR video.
+   */
+  isHDR: boolean;
+  /**
    * Width of the video in pixels.
    */
   width: number;

--- a/src/ExpoVideoMetadata.types.ts
+++ b/src/ExpoVideoMetadata.types.ts
@@ -8,9 +8,10 @@ export type VideoInfoResult = {
    */
   hasAudio: boolean;
   /**
-   * Available only on iOS >= 14. Tells if the video is a HDR video.
+   * Available only on iOS >= 14 and Android. Tells if the video is a HDR video.
+   * Will return null if it could not be determined.
    */
-  isHDR: boolean;
+  isHDR: boolean | null;
   /**
    * Width of the video in pixels.
    */

--- a/src/ExpoVideoMetadataModule.web.ts
+++ b/src/ExpoVideoMetadataModule.web.ts
@@ -194,6 +194,7 @@ export default {
           hasAudio,
           audioSampleRate, // Not available
           audioChannels, // Not available
+          isHDR: null, // Not available
           audioCodec,
           codec: videoCodec,
           fps, // Not available


### PR DESCRIPTION
Hey,

this is my first ever iOS/Swift PR and I'm not an iOS developer. So please check this with caution.

The way that I check whether its a HDR video or not, only works with iOS 14 or above. So I'm not quite sure what the preferred API design is in this case (e.g. what value should be returned for "isHDR" below iOS 14 or on Android phones)?

My decision was that "isHDR" should only be returned when we are able to fetch this information.

I tested it with different HDR and non-HDR videos. 

However, as I noticed, the code only checks the first video track in the asset. I am absolutely clueless whether its possible that asset shave multiple video tracks and if we should check these tracks as well. 