### PR TITLE
Normalize web codec names

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,22 @@
+# TODO
+
+## Expose full codec parameter strings
+
+The public `codec` and `audioCodec` fields are currently normalized to codec family names for platform parity:
+
+- `mp4a.40.2` -> `aac`
+- `avc` -> `avc1`
+- `hevc` -> `hev1`
+
+This keeps web, iOS, and Android easier to compare. Mediabunny can expose richer codec parameter strings on web, such as `mp4a.40.2` or `avc1.640028`, which may be useful for compatibility checks and debugging.
+
+Revisit adding separate fields in a future minor release:
+
+```ts
+codec: "avc1";
+codecString: "avc1.640028";
+audioCodec: "aac";
+audioCodecString: "mp4a.40.2";
+```
+
+Do not replace the existing normalized fields without a breaking change.

--- a/src/ExpoVideoMetadataModule.web.ts
+++ b/src/ExpoVideoMetadataModule.web.ts
@@ -193,6 +193,29 @@ function findLocationInMetadata(metadata: MetadataTags): Location {
   return null;
 }
 
+function normalizeVideoCodec(codec: string | null, codecParameterString: string | null) {
+  switch (codec) {
+    case "avc":
+      return "avc1";
+    case "hevc":
+      return "hev1";
+    default:
+      return codec ?? codecParameterString?.split(".")[0] ?? "";
+  }
+}
+
+function normalizeAudioCodec(codec: string | null, codecParameterString: string | null) {
+  if (codec) {
+    return codec;
+  }
+
+  if (codecParameterString?.startsWith("mp4a")) {
+    return "aac";
+  }
+
+  return codecParameterString?.split(".")[0] ?? "";
+}
+
 function createRemoteReadError(source: string, cause: unknown) {
   const error = new Error(
     `Failed to read remote video metadata from '${source}'. On web, remote videos must allow CORS and byte-range requests.`
@@ -268,7 +291,7 @@ export default {
           (sourceInfo.fileSize && duration
             ? Math.floor((sourceInfo.fileSize * 8) / duration)
             : 0);
-        codec = videoCodecParameterString ?? videoCodec ?? "";
+        codec = normalizeVideoCodec(videoCodec, videoCodecParameterString);
         isHDR = videoIsHDR;
         orientation = getOrientation(rotation, width, height);
       }
@@ -288,7 +311,7 @@ export default {
 
         audioSampleRate = sampleRate;
         audioChannels = numberOfChannels;
-        audioCodec = audioCodecParameterString ?? codec ?? "";
+        audioCodec = normalizeAudioCodec(codec, audioCodecParameterString);
       }
 
       const aspectRatio = width > 0 && height > 0 ? width / height : 0;


### PR DESCRIPTION
## Summary
- normalize Mediabunny codec output to match native codec family names
- document future separate codec string fields for richer codec parameter data

## Validation
- yarn tsc --noEmit
- yarn tsc -p tsconfig.json
- yarn tsc --noEmit in example