### PR TITLE
Add manual npm bump workflow

### DIFF
--- a/.github/workflows/npm-bump.yml
+++ b/.github/workflows/npm-bump.yml
@@ -1,0 +1,57 @@
+name: NPM Bump
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: Version type to bump manually
+        required: false
+        type: choice
+        options:
+          - ""
+          - patch
+          - minor
+          - major
+          - prerelease
+
+permissions:
+  contents: write
+
+jobs:
+  bump:
+    name: Bump package version
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: yarn
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build package
+        run: yarn build
+
+      - name: Typecheck package
+        run: yarn tsc --noEmit
+
+      - name: Manual version bump
+        uses: phips28/gh-action-bump-version@v11.0.7
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag-prefix: v
+          target-branch: main
+          commit-message: "chore: release {{version}} [skip ci]"
+          version-type: ${{ inputs.version_type }}


### PR DESCRIPTION
## Summary
- add a manual GitHub Actions workflow for bumping the package version
- validate install, build, and TypeScript before bumping
- use gh-action-bump-version with explicit manual version type selection

## Notes
- this workflow only runs through workflow_dispatch
- GITHUB_TOKEN is provided by GitHub Actions and uses contents: write permissions