### PR TITLE
Add configurable metadata extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ getVideoInfoAsync(
     headers?: Record<string, string>;
     exactDuration?: boolean;
     packetStatsSampleCount?: number | null;
+    includeMetadataTags?: boolean;
+    includeVideoTracks?: boolean;
+    includeAudioTracks?: boolean;
   }
 ): Promise<VideoInfoResult>
 ```
@@ -113,15 +116,34 @@ getVideoInfoAsync(
 
 Base64/data URLs work on web, but they are not ideal for large videos.
 
-By default, durations are read from metadata when possible and packet statistics
-inspect the first 30 packets of each track. That keeps metadata resolution fast
-for large files while still providing useful FPS and bitrate estimates.
+By default, durations are read from metadata when possible, video and audio
+tracks are included, packet statistics inspect the first 30 packets of each
+track, and metadata tags are skipped. Skipping tags avoids extra reads for title,
+artist, comments, embedded images, raw tags, and GPS location when you only need
+technical media metadata.
+
+Use `includeMetadataTags: true` when you need container tags or location data:
+
+```ts
+const info = await getVideoInfoAsync(source, {
+  includeMetadataTags: true,
+});
+```
+
+If you only need one media kind, disable the other one:
+
+```ts
+const info = await getVideoInfoAsync(source, {
+  includeAudioTracks: false,
+});
+```
 
 To match Mediabunny's metadata extraction demo more closely, use:
 
 ```ts
 const info = await getVideoInfoAsync(source, {
   exactDuration: true,
+  includeMetadataTags: true,
   packetStatsSampleCount: null,
 });
 ```
@@ -137,7 +159,7 @@ type VideoInfoResult = {
   start: number;
   end: number;
   tracks: MediaTrackInfo[];
-  metadataTags: MetadataTagsInfo | null;
+  metadataTags?: MetadataTagsInfo | null;
   fileSize: number;
 
   // Convenience fields derived from the primary video/audio tracks:
@@ -230,8 +252,10 @@ type MetadataTagsInfo = {
 };
 ```
 
-Some fields depend on what the file actually exposes. For example, location
-metadata is only returned when the video contains a readable GPS tag.
+Some fields depend on what the file actually exposes and what options you pass.
+For example, `metadataTags` and `location` are only read when
+`includeMetadataTags` is `true`, and location is only returned when the video
+contains a readable GPS tag.
 
 ## Example With Expo Image Picker
 
@@ -251,7 +275,9 @@ const result = await ImagePicker.launchImageLibraryAsync({
 
 if (!result.canceled) {
   const asset = result.assets[0];
-  const info = await getVideoInfoAsync(asset.file ?? asset.uri);
+  const info = await getVideoInfoAsync(asset.file ?? asset.uri, {
+    includeMetadataTags: true,
+  });
   console.log(info);
 }
 ```

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -32,6 +32,10 @@ type DisplayValue =
   | DisplayValue[]
   | { [key: string]: DisplayValue };
 
+const DEMO_OPTIONS = {
+  includeMetadataTags: true,
+};
+
 function isMetadataImage(value: unknown): value is MetadataImageInfo {
   return (
     value !== null &&
@@ -289,7 +293,7 @@ function AppContent() {
     setFileName(asset.fileName ?? asset.uri);
 
     try {
-      setResult(await getVideoInfoAsync(asset.file ?? asset.uri));
+      setResult(await getVideoInfoAsync(asset.file ?? asset.uri, DEMO_OPTIONS));
     } finally {
       setIsLoading(false);
     }
@@ -303,7 +307,7 @@ function AppContent() {
     setFileName(url);
 
     try {
-      setResult(await getVideoInfoAsync(url));
+      setResult(await getVideoInfoAsync(url, DEMO_OPTIONS));
     } finally {
       setIsLoading(false);
     }

--- a/src/ExpoVideoMetadata.types.ts
+++ b/src/ExpoVideoMetadata.types.ts
@@ -78,7 +78,7 @@ export type VideoInfoResult = {
   start: number;
   end: number;
   tracks: MediaTrackInfo[];
-  metadataTags: MetadataTagsInfo | null;
+  metadataTags?: MetadataTagsInfo | null;
   fileSize: number;
 
   /**
@@ -134,4 +134,26 @@ export type VideoInfoOptions = {
    * Defaults to `30`.
    */
   packetStatsSampleCount?: number | null;
+  /**
+   * Include container metadata tags such as title, artist, comments, embedded
+   * images, raw tags, and GPS location.
+   *
+   * Defaults to `false` because tag parsing can require extra reads and is not
+   * needed for basic technical video metadata.
+   */
+  includeMetadataTags?: boolean;
+  /**
+   * Include video tracks in the returned `tracks` array and derived video
+   * convenience fields.
+   *
+   * Defaults to `true`.
+   */
+  includeVideoTracks?: boolean;
+  /**
+   * Include audio tracks in the returned `tracks` array and derived audio
+   * convenience fields.
+   *
+   * Defaults to `true`.
+   */
+  includeAudioTracks?: boolean;
 };

--- a/src/getVideoInfo.ts
+++ b/src/getVideoInfo.ts
@@ -79,6 +79,18 @@ function getPacketStatsSampleCount(options: VideoInfoOptions) {
     : options.packetStatsSampleCount;
 }
 
+function shouldIncludeTrack(track: InputTrack, options: VideoInfoOptions) {
+  if (track.isVideoTrack()) {
+    return options.includeVideoTracks !== false;
+  }
+
+  if (track.isAudioTrack()) {
+    return options.includeAudioTracks !== false;
+  }
+
+  return true;
+}
+
 async function getPacketStats(
   track: InputTrack,
   options: VideoInfoOptions
@@ -378,21 +390,22 @@ export async function getVideoInfo(
 
   try {
     const sourceInfo = await createSourceInfo(source, options);
-    input = new Input({
+    const mediaInput = new Input({
       formats: ALL_FORMATS,
       source: sourceInfo.source,
     });
+    input = mediaInput;
 
-    const [tracks, metadata] = await Promise.all([
-      input.getTracks(),
-      input.getMetadataTags(),
-    ]);
+    const tracks = await mediaInput.getTracks();
+    const includedTracks = tracks.filter((track) => shouldIncludeTrack(track, options));
     const [format, mimeType, start, end, trackInfo] = await Promise.all([
-      input.getFormat().then((format) => format.name),
-      input.getMimeType(),
-      safeRead(() => input!.getFirstTimestamp(tracks), 0),
-      getDuration(input, tracks, options),
-      Promise.all(tracks.map((track) => getTrackInfo(track, options))),
+      mediaInput.getFormat().then((format) => format.name),
+      mediaInput.getMimeType(),
+      includedTracks.length
+        ? safeRead(() => mediaInput.getFirstTimestamp(includedTracks), 0)
+        : 0,
+      includedTracks.length ? getDuration(mediaInput, includedTracks, options) : 0,
+      Promise.all(includedTracks.map((track) => getTrackInfo(track, options))),
     ]);
 
     const videoTrack = trackInfo.find(
@@ -401,7 +414,10 @@ export async function getVideoInfo(
     const audioTrack = trackInfo.find(
       (track): track is AudioTrackInfo => track.type === "audio"
     );
-    const metadataTags = normalizeMetadataTags(metadata);
+    const metadata = options.includeMetadataTags
+      ? await safeRead(() => mediaInput.getMetadataTags(), null)
+      : null;
+    const metadataTags = metadata ? normalizeMetadataTags(metadata) : undefined;
     const duration = Math.max(0, end - start);
     const width = videoTrack?.codedWidth ?? 0;
     const height = videoTrack?.codedHeight ?? 0;
@@ -418,7 +434,7 @@ export async function getVideoInfo(
       start,
       end,
       tracks: trackInfo,
-      metadataTags,
+      ...(options.includeMetadataTags ? { metadataTags: metadataTags ?? null } : {}),
       fileSize: sourceInfo.fileSize,
       duration,
       width,
@@ -441,7 +457,7 @@ export async function getVideoInfo(
       aspectRatio,
       is16_9: Math.abs(aspectRatio - 16 / 9) < 0.01,
       naturalOrientation: height > width ? "Portrait" : "Landscape",
-      location: findLocationInMetadata(metadata),
+      location: metadata ? findLocationInMetadata(metadata) : null,
     };
   } catch (error) {
     if (typeof source === "string" && isLocalFileSource(source)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,9 +20,10 @@ export type {
  * Retrieves video metadata.
  *
  * @param source A local or remote URI. On web, it can also be a File or Blob.
- * @param options Pass `headers` for remote URIs. Use `exactDuration` or
- * `packetStatsSampleCount: null` when you need full scans instead of fast
- * metadata estimates.
+ * @param options Pass `headers` for remote URIs. Use `includeMetadataTags`
+ * for container tags/GPS, `includeAudioTracks` or `includeVideoTracks` to
+ * narrow extraction, and `exactDuration` or `packetStatsSampleCount: null`
+ * when you need full scans instead of fast metadata estimates.
  *
  * @return Returns a promise which fulfils with [`VideoInfoResult`](#Videoinforesult).
  */


### PR DESCRIPTION
## Summary
- skip metadata tag parsing by default for faster technical metadata reads
- add options to include metadata tags and to disable video or audio track extraction when not needed
- update the example to opt into metadata tags for the inspector UI
- document the new defaults and options

## Defaults
- video tracks are included by default
- audio tracks are included by default
- metadata tags are skipped by default

## Validation
- yarn tsc -p example/tsconfig.json --noEmit
- yarn build
- git diff --check